### PR TITLE
Handle non-200 responses when requesting saml

### DIFF
--- a/oktaauth/main.py
+++ b/oktaauth/main.py
@@ -78,12 +78,16 @@ URL: <{url}>
                                config.apptype, config.appid,
                                config.username, password, passcode)
 
-    print(okta.auth())
+    try:
+        print(okta.auth())
+        return 0
+    except Exception as e:
+        log.error('Error authorising with okta: %s' % e)
+        return 1
+    finally:
+        del password
+        del passcode
 
-    del password
-    del passcode
-
-    return 0
 
 def entry_point():
     """Zero-argument entry point for use with setuptools/distribute."""

--- a/oktaauth/models.py
+++ b/oktaauth/models.py
@@ -105,6 +105,10 @@ class OktaSamlAuth(OktaAPIAuth):
     def saml(self, sessionToken):
         url = '{base}/app/{app}/{appid}/sso/saml'.format(base=self.okta_url, app=self.application_type, appid=self.application_id)
         resp = requests.get(url=url, params={'onetimetoken': sessionToken})
+
+        if resp.status_code != 200:
+            raise Exception('Received error code from server: %s' % resp.status_code)
+
         return resp.text.decode('utf8')
 
     def assertion(self, saml):


### PR DESCRIPTION
Pretty basic handling, but does at least present a message to the user,
rather than a stack trace.