### PR TITLE
Fix to invalid reference in non two-factor case.

### DIFF
--- a/oktaauth/models.py
+++ b/oktaauth/models.py
@@ -64,7 +64,7 @@ class OktaAPIAuth(object):
                 status = rv['status']
             if status == 'SUCCESS':
                 log.info('User %s authenticated without MFA' % self.username)
-                return res['sessionToken']
+                return rv['sessionToken']
             if status == 'MFA_ENROLL' or status == 'MFA_ENROLL_ACTIVATE':
                 log.info('User %s needs to enroll first' % self.username)
                 return False


### PR DESCRIPTION
Looks like the "res" variable was meant to be "rv" because res doesn't exist in the case where two factor isn't used.